### PR TITLE
Allow filesystem writes in dev/multidev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ web/*
 !web/wp-cli.yml
 !web/wp-config.php
 !web/wp-config-pantheon.php
+!web/wp-config-local-sample.php
 !web/wp-content/
 web/wp-content/*
 !web/wp-content/mu-plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ web/*
 !web/index.php
 !web/wp-cli.yml
 !web/wp-config.php
+!web/wp-config-pantheon.php
 !web/wp-content/
 web/wp-content/*
 !web/wp-content/mu-plugins/

--- a/web/wp-config-local-sample.php
+++ b/web/wp-config-local-sample.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This is a sample config for local development. wp-config.php will
+ * load this file if you're not in a Pantheon environment. Simply edit/copy
+ * as needed and rename to wp-config-local.php.
+ *
+ * Be sure to replace YOUR LOCAL DOMAIN below too.
+ */
+
+define( 'DB_NAME', 'database_name' );
+define( 'DB_USER', 'database_username' );
+define( 'DB_PASSWORD', 'database_password' );
+define( 'DB_HOST', 'database_host' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+define( 'AUTH_KEY', 'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY', 'put your unique phrase here' );
+define( 'LOGGED_IN_KEY', 'put your unique phrase here' );
+define( 'NONCE_KEY', 'put your unique phrase here' );
+define( 'AUTH_SALT', 'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT', 'put your unique phrase here' );
+define( 'NONCE_SALT', 'put your unique phrase here' );
+
+define( 'WP_DEBUG', true );
+define( 'WP_DEBUG_LOG', true );
+define( 'WP_DEBUG_DISPLAY', true );
+
+define( 'WP_HOME', '<YOUR LOCAL DOMAIN>' );
+define( 'WP_SITEURL', '<YOUR LOCAL DOMAIN>' );
+
+define( 'WP_AUTO_UPDATE_CORE', false );

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -98,3 +98,10 @@ if (getenv('WP_ENVIRONMENT_TYPE') === false) {
             break;
     }
 }
+
+/**
+ * Force SSL
+ */
+if ( ! defined('FORCE_SSL_ADMIN') ) {
+    define( 'FORCE_SSL_ADMIN', true );
+}

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -1,5 +1,15 @@
 <?php
 /**
+ * Set root path
+ */
+$rootPath = realpath( __DIR__ . '/..' );
+
+/**
+ * Include the Composer autoload
+ */
+require_once( $rootPath . '/vendor/autoload.php' );
+
+/**
  * Pantheon platform settings.
  *
  * IMPORTANT NOTE:

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Pantheon platform settings.
+ *
+ * IMPORTANT NOTE:
+ * Do not modify this file. This file is maintained by Pantheon.
+ *
+ * Site-specific modifications belong in wp-config.php, not this file. This
+ * file may change in future releases and modifications would cause conflicts
+ * when attempting to apply upstream updates.
+ */
+
+// ** MySQL settings - included in the Pantheon Environment ** //
+/** The name of the database for WordPress */
+define('DB_NAME', $_ENV['DB_NAME']);
+
+/** MySQL database username */
+define('DB_USER', $_ENV['DB_USER']);
+
+/** MySQL database password */
+define('DB_PASSWORD', $_ENV['DB_PASSWORD']);
+
+/** MySQL hostname; on Pantheon this includes a specific port number. */
+define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
+
+/** Database Charset to use in creating database tables. */
+define('DB_CHARSET', 'utf8mb4');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Changing these will force all users to have to log in again.
+ * Pantheon sets these values for you. If you want to shuffle them you must
+ * contact support: https://pantheon.io/docs/getting-support
+ *
+ * @since 2.6.0
+ */
+define('AUTH_KEY', $_ENV['AUTH_KEY']);
+define('SECURE_AUTH_KEY', $_ENV['SECURE_AUTH_KEY']);
+define('LOGGED_IN_KEY', $_ENV['LOGGED_IN_KEY']);
+define('NONCE_KEY', $_ENV['NONCE_KEY']);
+define('AUTH_SALT', $_ENV['AUTH_SALT']);
+define('SECURE_AUTH_SALT', $_ENV['SECURE_AUTH_SALT']);
+define('LOGGED_IN_SALT', $_ENV['LOGGED_IN_SALT']);
+define('NONCE_SALT', $_ENV['NONCE_SALT']);
+/**#@-*/
+
+/** A couple extra tweaks to help things run well on Pantheon. **/
+if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+    // HTTP is still the default scheme for now.
+    $scheme = 'http';
+    // If we have detected that the end use is HTTPS, make sure we pass that
+    // through here, so <img> tags and the like don't generate mixed-mode
+    // content warnings.
+    if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
+        $scheme = 'https';
+    }
+    define( 'WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST'] );
+    define( 'WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST'] . '/wp' );
+
+}
+
+// Don't show deprecations; useful under PHP 5.5
+error_reporting(E_ALL ^ E_DEPRECATED);
+/** Define appropriate location for default tmp directory on Pantheon */
+define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
+
+// FS writes aren't permitted in test or live, so we should let WordPress know to
+// disable relevant UI.
+if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) ) {
+    $constants = [
+        'DISALLOW_FILE_MODS',
+        'DISALLOW_FILE_EDIT',
+    ];
+    foreach ($constant as $constants) {
+        if ( ! defined($constant) ) {
+            define( $constant, true );
+        }
+    }	
+}
+
+/**
+ * Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment
+ */
+if (getenv('WP_ENVIRONMENT_TYPE') === false) {
+    switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+        case 'live':
+            putenv('WP_ENVIRONMENT_TYPE=production');
+            break;
+        case 'test':
+            putenv('WP_ENVIRONMENT_TYPE=staging');
+            break;
+        default:
+            putenv('WP_ENVIRONMENT_TYPE=development');
+            break;
+    }
+}

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -81,14 +81,11 @@ define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
 // FS writes aren't permitted in test or live, so we should let WordPress know to
 // disable relevant UI.
 if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) ) {
-    $constants = [
-        'DISALLOW_FILE_MODS',
-        'DISALLOW_FILE_EDIT',
-    ];
-    foreach ($constant as $constants) {
-        if ( ! defined($constant) ) {
-            define( $constant, true );
-        }
+    if ( ! defined('DISALLOW_FILE_MODS') ) {
+        define( 'DISALLOW_FILE_MODS', true );
+    }
+    if ( ! defined('DISALLOW_FILE_EDIT') ) {
+        define( 'DISALLOW_FILE_EDIT', true );
     }	
 }
 

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -1,15 +1,5 @@
 <?php
 /**
- * Set root path
- */
-$rootPath = realpath( __DIR__ . '/..' );
-
-/**
- * Include the Composer autoload
- */
-require_once( $rootPath . '/vendor/autoload.php' );
-
-/**
  * Pantheon platform settings. Everything you need should already be set.
  */
 if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -72,8 +72,9 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 /* That's all, stop editing! Happy Pressing. */
 
 /** Absolute path to the WordPress directory. */
-if ( !defined('ABSPATH') )
+if ( !defined('ABSPATH') ) {
 	define('ABSPATH', dirname(__FILE__) . '/');
+}
 
 /** Sets up WordPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -27,11 +27,11 @@ if ( ! isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && file_exists( $rootPath . '/.env
 	) )->notEmpty();
 }
 
-/**
- * Disallow on server file edits
- */
-define( 'DISALLOW_FILE_EDIT', true );
-define( 'DISALLOW_FILE_MODS', true );
+// FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
+if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' )) && ! defined('DISALLOW_FILE_MODS')) {
+    define( 'DISALLOW_FILE_EDIT', true );
+    define( 'DISALLOW_FILE_MODS', true );
+}
 
 /**
  * Force SSL

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -14,25 +14,6 @@ $rootPath = realpath( __DIR__ . '/..' );
  */
 require_once( $rootPath . '/vendor/autoload.php' );
 
-/*
- * Fetch .env
- */
-if ( ! isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && file_exists( $rootPath . '/.env' ) ) {
-	$dotenv = Dotenv\Dotenv::create($rootPath);
-	$dotenv->load();
-	$dotenv->required( array(
-		'DB_NAME',
-		'DB_USER',
-		'DB_HOST',
-	) )->notEmpty();
-}
-
-// FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
-if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' )) && ! defined('DISALLOW_FILE_MODS')) {
-    define( 'DISALLOW_FILE_EDIT', true );
-    define( 'DISALLOW_FILE_MODS', true );
-}
-
 /**
  * Force SSL
  */
@@ -44,62 +25,22 @@ define( 'FORCE_SSL_ADMIN', true );
 define( 'WP_POST_REVISIONS', 3 );
 
 /*
- * If NOT on Pantheon
- */
-if ( ! isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
-	/**
-	 * Define site and home URLs
-	 */
-	// HTTP is still the default scheme for now.
-	$scheme = 'http';
-	// If we have detected that the end use is HTTPS, make sure we pass that
-	// through here, so <img> tags and the like don't generate mixed-mode
-	// content warnings.
-	if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
-		$scheme = 'https';
-	}
-	$site_url = getenv( 'WP_HOME' ) !== false ? getenv( 'WP_HOME' ) : $scheme . '://' . $_SERVER['HTTP_HOST'] . '/';
-	define( 'WP_HOME', $site_url );
-	define( 'WP_SITEURL', $site_url . 'wp/' );
-
-	/**
-	 * Set Database Details
-	 */
-	define( 'DB_NAME', getenv( 'DB_NAME' ) );
-	define( 'DB_USER', getenv( 'DB_USER' ) );
-	define( 'DB_PASSWORD', getenv( 'DB_PASSWORD' ) !== false ? getenv( 'DB_PASSWORD' ) : '' );
-	define( 'DB_HOST', getenv( 'DB_HOST' ) );
-
-	/**
-	 * Set debug modes
-	 */
-	define( 'WP_DEBUG', getenv( 'WP_DEBUG' ) === 'true' ? true : false );
-	define( 'IS_LOCAL', getenv( 'IS_LOCAL' ) !== false ? true : false );
-
-	/**#@+
-	 * Authentication Unique Keys and Salts.
-	 *
-	 * Change these to different unique phrases!
-	 * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
-	 * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
-	 *
-	 * @since 2.6.0
-	 */
-	define( 'AUTH_KEY', '^J/U[^{cOJxhcmmCq2MX%nUs}i_^7nm[w+VsetLZ[JXW9Un/IiyWVEXk;s}X=?u$' );
-	define( 'SECURE_AUTH_KEY', 'dT,wlW20L5V3ChmTEHFGVtUE-r&A)y+G%Pnql&eKdVAWvdIr9FO4lh_Gc9ZVn!1|' );
-	define( 'LOGGED_IN_KEY', '{0E{}k_e7!XRt*}h}nuMP[sKn$gb(O@|[>?bUs}B{>:|+|lL%czE/!Tlc Uk53#:' );
-	define( 'NONCE_KEY', '|M9$H1t9D@AR6>JM[]?9RoA^dmOCHt6ldAE%x|0 Iqpi+m32>1>?0*_?*#|6f7|W' );
-	define( 'AUTH_SALT', 'CA-BmAsS|o_P|!I8Wfu%a=qXC;!3p[8]W_:N2{oI]HhpLP(%2]zWLH+aHTHDw9>%' );
-	define( 'SECURE_AUTH_SALT', 'pi-EA,AOXk*U[VZ|t]R;@K<WMcbD)>k* ;8+hKX:A|$.Z@HL@0`SE?W0:-?-IRd!' );
-	define( 'LOGGED_IN_SALT', 'e+6%u)u@RZn-$}_Q[N;Na<|A-[Am_$#nhD~}ci:%R&B*oiq<sPF$v)d1r<-V-5W|' );
-	define( 'NONCE_SALT', 'r%oyx_`[A-~<LB)]I.,^//}/&]a)H|fzk3IUWrZn[L4qf#Pp#lsB-B}+/ai&u,/|' );
-
-endif;
-
-/*
  * If on Pantheon
  */
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
+	// FS writes aren't permitted in test or live, so we should let WordPress know to
+	// disable relevant UI.
+	if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) ) {
+		$constants = [
+			'DISALLOW_FILE_MODS',
+			'DISALLOW_FILE_EDIT',
+		];
+		foreach ($constant as $constants) {
+			if ( ! defined($constant) ) {
+				define( $constant, true );
+			}
+		}	
+	}
 
 	// ** MySQL settings - included in the Pantheon Environment ** //
 	/** The name of the database for WordPress */
@@ -166,6 +107,67 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 	if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) && ! defined( 'DISALLOW_FILE_MODS' ) ) :
 		define( 'DISALLOW_FILE_MODS', true );
 	endif;
+
+else:
+	/*
+	* Fetch .env
+	*/
+	if ( file_exists( $rootPath . '/.env' ) ) {
+		$dotenv = Dotenv\Dotenv::create($rootPath);
+		$dotenv->load();
+		$dotenv->required( array(
+			'DB_NAME',
+			'DB_USER',
+			'DB_HOST',
+		) )->notEmpty();
+	}
+
+	/**
+	 * Define site and home URLs
+	 */
+	// HTTP is still the default scheme for now.
+	$scheme = 'http';
+	// If we have detected that the end use is HTTPS, make sure we pass that
+	// through here, so <img> tags and the like don't generate mixed-mode
+	// content warnings.
+	if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
+		$scheme = 'https';
+	}
+	$site_url = getenv( 'WP_HOME' ) !== false ? getenv( 'WP_HOME' ) : $scheme . '://' . $_SERVER['HTTP_HOST'] . '/';
+	define( 'WP_HOME', $site_url );
+	define( 'WP_SITEURL', $site_url . 'wp/' );
+
+	/**
+	 * Set Database Details
+	 */
+	define( 'DB_NAME', getenv( 'DB_NAME' ) );
+	define( 'DB_USER', getenv( 'DB_USER' ) );
+	define( 'DB_PASSWORD', getenv( 'DB_PASSWORD' ) !== false ? getenv( 'DB_PASSWORD' ) : '' );
+	define( 'DB_HOST', getenv( 'DB_HOST' ) );
+
+	/**
+	 * Set debug modes
+	 */
+	define( 'WP_DEBUG', getenv( 'WP_DEBUG' ) === 'true' ? true : false );
+	define( 'IS_LOCAL', getenv( 'IS_LOCAL' ) !== false ? true : false );
+
+	/**#@+
+	 * Authentication Unique Keys and Salts.
+	 *
+	 * Change these to different unique phrases!
+	 * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+	 * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+	 *
+	 * @since 2.6.0
+	 */
+	define( 'AUTH_KEY', '^J/U[^{cOJxhcmmCq2MX%nUs}i_^7nm[w+VsetLZ[JXW9Un/IiyWVEXk;s}X=?u$' );
+	define( 'SECURE_AUTH_KEY', 'dT,wlW20L5V3ChmTEHFGVtUE-r&A)y+G%Pnql&eKdVAWvdIr9FO4lh_Gc9ZVn!1|' );
+	define( 'LOGGED_IN_KEY', '{0E{}k_e7!XRt*}h}nuMP[sKn$gb(O@|[>?bUs}B{>:|+|lL%czE/!Tlc Uk53#:' );
+	define( 'NONCE_KEY', '|M9$H1t9D@AR6>JM[]?9RoA^dmOCHt6ldAE%x|0 Iqpi+m32>1>?0*_?*#|6f7|W' );
+	define( 'AUTH_SALT', 'CA-BmAsS|o_P|!I8Wfu%a=qXC;!3p[8]W_:N2{oI]HhpLP(%2]zWLH+aHTHDw9>%' );
+	define( 'SECURE_AUTH_SALT', 'pi-EA,AOXk*U[VZ|t]R;@K<WMcbD)>k* ;8+hKX:A|$.Z@HL@0`SE?W0:-?-IRd!' );
+	define( 'LOGGED_IN_SALT', 'e+6%u)u@RZn-$}_Q[N;Na<|A-[Am_$#nhD~}ci:%R&B*oiq<sPF$v)d1r<-V-5W|' );
+	define( 'NONCE_SALT', 'r%oyx_`[A-~<LB)]I.,^//}/&]a)H|fzk3IUWrZn[L4qf#Pp#lsB-B}+/ai&u,/|' );
 
 endif;
 

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -15,15 +15,21 @@ $rootPath = realpath( __DIR__ . '/..' );
 require_once( $rootPath . '/vendor/autoload.php' );
 
 /**
- * Force SSL
- */
-define( 'FORCE_SSL_ADMIN', true );
-
-/**
  * Pantheon platform settings. Everything you need should already be set.
  */
 if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 	require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
+
+/**
+ * Local configuration information.
+ *
+ * If you are working in a local/desktop development environment and want to
+ * keep your config separate, we recommend using a 'wp-config-local.php' file,
+ * which you should also make sure you .gitignore.
+ */
+} elseif (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])){
+	# IMPORTANT: ensure your local config does not include wp-settings.php
+	require_once(dirname(__FILE__) . '/wp-config-local.php');
 
 /**
  * This block will be executed if you are NOT running on Pantheon and have NO

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -1,9 +1,4 @@
 <?php
-/*
- * Don't show deprecations
- */
-error_reporting( E_ALL ^ E_DEPRECATED );
-
 /**
  * Set root path
  */

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -20,156 +20,33 @@ require_once( $rootPath . '/vendor/autoload.php' );
 define( 'FORCE_SSL_ADMIN', true );
 
 /**
- * Limit post revisions
+ * Pantheon platform settings. Everything you need should already be set.
  */
-define( 'WP_POST_REVISIONS', 3 );
+if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+	require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
 
-/*
- * If on Pantheon
+/**
+ * This block will be executed if you are NOT running on Pantheon and have NO
+ * wp-config-local.php. Insert alternate config here if necessary.
+ *
+ * If you are only running on Pantheon, you can ignore this block.
  */
-if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
-	// FS writes aren't permitted in test or live, so we should let WordPress know to
-	// disable relevant UI.
-	if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) ) {
-		$constants = [
-			'DISALLOW_FILE_MODS',
-			'DISALLOW_FILE_EDIT',
-		];
-		foreach ($constant as $constants) {
-			if ( ! defined($constant) ) {
-				define( $constant, true );
-			}
-		}	
-	}
-
-	// ** MySQL settings - included in the Pantheon Environment ** //
-	/** The name of the database for WordPress */
-	define( 'DB_NAME', $_ENV['DB_NAME'] );
-
-	/** MySQL database username */
-	define( 'DB_USER', $_ENV['DB_USER'] );
-
-	/** MySQL database password */
-	define( 'DB_PASSWORD', $_ENV['DB_PASSWORD'] );
-
-	/** MySQL hostname; on Pantheon this includes a specific port number. */
-	define( 'DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT'] );
-
-	/** Database Charset to use in creating database tables. */
-	define( 'DB_CHARSET', 'utf8' );
-
-	/** The Database Collate type. Don't change this if in doubt. */
-	define( 'DB_COLLATE', '' );
-
-	/**#@+
-	 * Authentication Unique Keys and Salts.
-	 *
-	 * Change these to different unique phrases!
-	 * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
-	 * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
-	 *
-	 * Pantheon sets these values for you also. If you want to shuffle them you
-	 * can do so via your dashboard.
-	 *
-	 * @since 2.6.0
-	 */
-	define( 'AUTH_KEY', $_ENV['AUTH_KEY'] );
-	define( 'SECURE_AUTH_KEY', $_ENV['SECURE_AUTH_KEY'] );
-	define( 'LOGGED_IN_KEY', $_ENV['LOGGED_IN_KEY'] );
-	define( 'NONCE_KEY', $_ENV['NONCE_KEY'] );
-	define( 'AUTH_SALT', $_ENV['AUTH_SALT'] );
-	define( 'SECURE_AUTH_SALT', $_ENV['SECURE_AUTH_SALT'] );
-	define( 'LOGGED_IN_SALT', $_ENV['LOGGED_IN_SALT'] );
-	define( 'NONCE_SALT', $_ENV['NONCE_SALT'] );
-	/**#@-*/
-
-	/** A couple extra tweaks to help things run well on Pantheon. **/
-	if ( isset( $_SERVER['HTTP_HOST'] ) ) {
-		// HTTP is still the default scheme for now.
-		$scheme = 'http';
-		// If we have detected that the end use is HTTPS, make sure we pass that
-		// through here, so <img> tags and the like don't generate mixed-mode
-		// content warnings.
-		if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
-			$scheme = 'https';
-		}
-		define( 'WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST'] );
-		define( 'WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST'] . '/wp' );
-
-	}
-
-	// Force the use of a safe temp directory when in a container
-	if ( defined( 'PANTHEON_BINDING' ) ):
-		define( 'WP_TEMP_DIR', sprintf( '/srv/bindings/%s/tmp', PANTHEON_BINDING ) );
-	endif;
-
-	// FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
-	if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) && ! defined( 'DISALLOW_FILE_MODS' ) ) :
-		define( 'DISALLOW_FILE_MODS', true );
-	endif;
-
-else:
-	/*
-	* Fetch .env
-	*/
-	if ( file_exists( $rootPath . '/.env' ) ) {
-		$dotenv = Dotenv\Dotenv::create($rootPath);
-		$dotenv->load();
-		$dotenv->required( array(
-			'DB_NAME',
-			'DB_USER',
-			'DB_HOST',
-		) )->notEmpty();
-	}
-
-	/**
-	 * Define site and home URLs
-	 */
-	// HTTP is still the default scheme for now.
-	$scheme = 'http';
-	// If we have detected that the end use is HTTPS, make sure we pass that
-	// through here, so <img> tags and the like don't generate mixed-mode
-	// content warnings.
-	if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
-		$scheme = 'https';
-	}
-	$site_url = getenv( 'WP_HOME' ) !== false ? getenv( 'WP_HOME' ) : $scheme . '://' . $_SERVER['HTTP_HOST'] . '/';
-	define( 'WP_HOME', $site_url );
-	define( 'WP_SITEURL', $site_url . 'wp/' );
-
-	/**
-	 * Set Database Details
-	 */
-	define( 'DB_NAME', getenv( 'DB_NAME' ) );
-	define( 'DB_USER', getenv( 'DB_USER' ) );
-	define( 'DB_PASSWORD', getenv( 'DB_PASSWORD' ) !== false ? getenv( 'DB_PASSWORD' ) : '' );
-	define( 'DB_HOST', getenv( 'DB_HOST' ) );
-
-	/**
-	 * Set debug modes
-	 */
-	define( 'WP_DEBUG', getenv( 'WP_DEBUG' ) === 'true' ? true : false );
-	define( 'IS_LOCAL', getenv( 'IS_LOCAL' ) !== false ? true : false );
-
-	/**#@+
-	 * Authentication Unique Keys and Salts.
-	 *
-	 * Change these to different unique phrases!
-	 * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
-	 * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
-	 *
-	 * @since 2.6.0
-	 */
-	define( 'AUTH_KEY', '^J/U[^{cOJxhcmmCq2MX%nUs}i_^7nm[w+VsetLZ[JXW9Un/IiyWVEXk;s}X=?u$' );
-	define( 'SECURE_AUTH_KEY', 'dT,wlW20L5V3ChmTEHFGVtUE-r&A)y+G%Pnql&eKdVAWvdIr9FO4lh_Gc9ZVn!1|' );
-	define( 'LOGGED_IN_KEY', '{0E{}k_e7!XRt*}h}nuMP[sKn$gb(O@|[>?bUs}B{>:|+|lL%czE/!Tlc Uk53#:' );
-	define( 'NONCE_KEY', '|M9$H1t9D@AR6>JM[]?9RoA^dmOCHt6ldAE%x|0 Iqpi+m32>1>?0*_?*#|6f7|W' );
-	define( 'AUTH_SALT', 'CA-BmAsS|o_P|!I8Wfu%a=qXC;!3p[8]W_:N2{oI]HhpLP(%2]zWLH+aHTHDw9>%' );
-	define( 'SECURE_AUTH_SALT', 'pi-EA,AOXk*U[VZ|t]R;@K<WMcbD)>k* ;8+hKX:A|$.Z@HL@0`SE?W0:-?-IRd!' );
-	define( 'LOGGED_IN_SALT', 'e+6%u)u@RZn-$}_Q[N;Na<|A-[Am_$#nhD~}ci:%R&B*oiq<sPF$v)d1r<-V-5W|' );
-	define( 'NONCE_SALT', 'r%oyx_`[A-~<LB)]I.,^//}/&]a)H|fzk3IUWrZn[L4qf#Pp#lsB-B}+/ai&u,/|' );
-
-endif;
+} else {
+	define('DB_NAME',          'database_name');
+	define('DB_USER',          'database_username');
+	define('DB_PASSWORD',      'database_password');
+	define('DB_HOST',          'database_host');
+	define('DB_CHARSET',       'utf8');
+	define('DB_COLLATE',       '');
+	define('AUTH_KEY',         'put your unique phrase here');
+	define('SECURE_AUTH_KEY',  'put your unique phrase here');
+	define('LOGGED_IN_KEY',    'put your unique phrase here');
+	define('NONCE_KEY',        'put your unique phrase here');
+	define('AUTH_SALT',        'put your unique phrase here');
+	define('SECURE_AUTH_SALT', 'put your unique phrase here');
+	define('LOGGED_IN_SALT',   'put your unique phrase here');
+	define('NONCE_SALT',       'put your unique phrase here');
+}
 
 /*
 * Define wp-content directory outside of WordPress core directory
@@ -177,19 +54,35 @@ endif;
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content' );
 define( 'WP_CONTENT_URL', WP_HOME . '/wp-content' );
 
+/** Standard wp-config.php stuff from here on down. **/
+
 /**
  * WordPress Database Table prefix.
  *
- * You can have multiple installations in one database if you give each
- * a unique prefix. Only numbers, letters, and underscores please!
+ * You can have multiple installations in one database if you give each a unique
+ * prefix. Only numbers, letters, and underscores please!
  */
-$table_prefix = getenv( 'DB_PREFIX' ) !== false ? getenv( 'DB_PREFIX' ) : 'wp_';
+$table_prefix = 'wp_';
 
-/* That's all, stop editing! Happy blogging. */
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * You may want to examine $_ENV['PANTHEON_ENVIRONMENT'] to set this to be
+ * "true" in dev, but false in test and live.
+ */
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define('WP_DEBUG', false);
+}
+
+/* That's all, stop editing! Happy Pressing. */
 
 /** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-}
+if ( !defined('ABSPATH') )
+	define('ABSPATH', dirname(__FILE__) . '/');
+
 /** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );
+require_once(ABSPATH . 'wp-settings.php');

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -75,6 +75,5 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
-
 /** Sets up WordPress vars and included files. */
 require_once( ABSPATH . 'wp-settings.php' );

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -72,9 +72,9 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 /* That's all, stop editing! Happy Pressing. */
 
 /** Absolute path to the WordPress directory. */
-if ( !defined('ABSPATH') ) {
-	define('ABSPATH', dirname(__FILE__) . '/');
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 
 /** Sets up WordPress vars and included files. */
-require_once(ABSPATH . 'wp-settings.php');
+require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
Fixes CORE-2195: IC wordpress installation should have language selection page

**Background:**

By default WordPress pulls the language pack selected by the user during the installation process. This can only happen if it has write access to the filesystem. Otherwise that step is skipped.

PS: For the language selection page to be displayed we also need to select the SFTP mode when creating the custom upstream.