### PR TITLE
[CMS-391] Disable WP Cron

### DIFF
--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -77,6 +77,8 @@ if ( isset( $_SERVER['HTTP_HOST'] ) ) {
 error_reporting(E_ALL ^ E_DEPRECATED);
 /** Define appropriate location for default tmp directory on Pantheon */
 define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
+/** Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli */
+define('DISABLE_WP_CRON', true);
 
 // FS writes aren't permitted in test or live, so we should let WordPress know to
 // disable relevant UI.

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -77,8 +77,6 @@ if ( isset( $_SERVER['HTTP_HOST'] ) ) {
 error_reporting(E_ALL ^ E_DEPRECATED);
 /** Define appropriate location for default tmp directory on Pantheon */
 define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
-/** Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli */
-define('DISABLE_WP_CRON', true);
 
 // FS writes aren't permitted in test or live, so we should let WordPress know to
 // disable relevant UI.
@@ -113,4 +111,15 @@ if (getenv('WP_ENVIRONMENT_TYPE') === false) {
  */
 if ( ! defined('FORCE_SSL_ADMIN') ) {
     define( 'FORCE_SSL_ADMIN', true );
+}
+
+/**
+ * Defaults you may override
+ *
+ * To override, define your constant in your wp-config.php before wp-config-pantheon.php is required.
+ */
+
+/** Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli */
+if ( ! defined( 'DISABLE_WP_CRON' ) ) {
+	define( 'DISABLE_WP_CRON', true );
 }


### PR DESCRIPTION
This PR disables WP Cron.  Web page requests will no long spawn requests to run wp-cron.php.  Pantheon has added support for upstreams with a framwork of `wordpress` or `wordpress-network` to automatically run cron via wp-cli once an hour.